### PR TITLE
Fixed Darwin-specific undefined behavior in get_executable_directory()

### DIFF
--- a/src/filesystem_utils.h
+++ b/src/filesystem_utils.h
@@ -154,7 +154,7 @@ static path_t get_executable_directory()
 
     return path_t(filepath);
 }
-#elif __APPLE__ // _WIN32
+#elif ! __linux__ // _WIN32
 #include <libproc.h>
 static path_t get_executable_directory()
 {
@@ -174,7 +174,7 @@ static path_t get_executable_directory()
 
     return path_t(filepath);
 }
-#else // __APPLE__
+#else // ! __linux__
 static path_t get_executable_directory()
 {
     char filepath[256];
@@ -185,7 +185,7 @@ static path_t get_executable_directory()
 
     return path_t(filepath);
 }
-#endif // __APPLE__
+#endif // ! __linux__
 
 static bool filepath_is_readable(const path_t& path)
 {

--- a/src/filesystem_utils.h
+++ b/src/filesystem_utils.h
@@ -154,7 +154,27 @@ static path_t get_executable_directory()
 
     return path_t(filepath);
 }
-#else // _WIN32
+#elif __APPLE__ // _WIN32
+#include <libproc.h>
+static path_t get_executable_directory()
+{
+    char filepath[256];
+    filepath[0]='\0';
+
+    int pid = getpid();
+    int ret = proc_pidpath(pid, filepath, sizeof(filepath));
+
+    if ( ret <= 0 ) {
+        fprintf(stderr, "PID %d: proc_pidpath ();\n", pid);
+        fprintf(stderr, "    %s\n", strerror(errno));
+    } else {
+        char* slash = strrchr(filepath, '/');
+        slash[1] = '\0';
+    }
+
+    return path_t(filepath);
+}
+#else // __APPLE__
 static path_t get_executable_directory()
 {
     char filepath[256];
@@ -165,7 +185,7 @@ static path_t get_executable_directory()
 
     return path_t(filepath);
 }
-#endif // _WIN32
+#endif // __APPLE__
 
 static bool filepath_is_readable(const path_t& path)
 {


### PR DESCRIPTION
## What 

`SIGABRT` is received by the process on `Darwin`, due to

```c
readlink("/proc/self/exe", filepath, 256);
```
failing to fill in the buffer (`procfs` does not exist on Darwin).

This causes undefined behavior in the subsequent code: null pointer dereference and attempt to write to invalid memory location (`0x0000000000000001`)

**NOTE:** though  SIGABRT is received somewhat reproducibly, 

```sh
man 2 readlink
```

says nothing about buffer contents in case of an error, which potentially may delay the failure beyond get_executable_directory(), causing unknown side effects.

## Fix
using `proc_pidpath()` was implemented for Unix (primarily Darwin and other BSD systems).

## Tests

the project was build using `clang 17` from `nixpkgs`, on `macOS` running on `Apple MacBook Air M1`. The problem could not be reproduced anymore.

<details>
<summary>Click here for the details</summary>

```sh
$ arch
arm64

$ sw_vers

ProductName:		macOS
ProductVersion:		14.3.1
BuildVersion:		23D60
```

`build.sh`:

```bash
#!/usr/bin/env bash

set -e
set -o pipefail

CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME:-Darwin}

CMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS:--fuse-ld=lld}
OpenMP_C_FLAGS=${OpenMP_C_FLAGS:--Xclang -fopenmp}
OpenMP_CXX_FLAGS=${OpenMP_CXX_FLAGS:--Xclang -fopenmp}
USE_STATIC_MOLTENVK=${USE_STATIC_MOLTENVK:-ON}
CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES:-arm64}
CMAKE_CROSSCOMPILING=${CMAKE_CROSSCOMPILING:-ON}
CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR:-arm64}

if [ "$1" = "--debug" ]; then
    # this is how I caught it with lldb
    CMAKE_C_FLAGS="-fno-limit-debug-info -g ${CMAKE_C_FLAGS}"
    CMAKE_CXX_FLAGS="-fno-limit-debug-info -g ${CMAKE_CXX_FLAGS}"
else
    CMAKE_C_FLAGS=${CMAKE_C_FLAGS:--O3}
    CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS:--O3}
fi

mkdir -p build
cmake \
    -DCMAKE_SYSTEM_NAME="$CMAKE_SYSTEM_NAME" \
    -DCMAKE_C_FLAGS="$CMAKE_C_FLAGS" \
    -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
    -DCMAKE_EXE_LINKER_FLAGS="$CMAKE_EXE_LINKER_FLAGS" \
    -DOpenMP_C_FLAGS="$OpenMP_C_FLAGS" \
    -DOpenMP_CXX_FLAGS="$OpenMP_CXX_FLAGS" \
    -DUSE_STATIC_MOLTENVK="$USE_STATIC_MOLTENVK" \
    -DCMAKE_OSX_ARCHITECTURES="$CMAKE_OSX_ARCHITECTURES" \
    -DCMAKE_CROSSCOMPILING="$CMAKE_CROSSCOMPILING" \
    -DCMAKE_SYSTEM_PROCESSOR="$CMAKE_SYSTEM_PROCESSOR" \
    -G Ninja \
    -S src \
    -B build

cmake --build build
```

`shell.nix`:

```nix
with import <nixpkgs> { };
mkShell.override { inherit (llvmPackages_17) stdenv; } {
  buildInputs = with darwin.apple_sdk.frameworks;
    with llvmPackages_17; [
      openmp
      vulkan-headers
      vulkan-loader
      libcxx
      libcxxabi
      Metal
      QuartzCore
      CoreGraphics
      Cocoa
      IOKit
      IOSurface
      Foundation
    ];
  nativeBuildInputs = [ cmake ninja lld_17 glslang llvmPackages_17.bintools ];
}
```

```sh
$ nix-shell shell.nix --run './build.sh'
```

The resulted build unfortunately could not find valid GPU ( which is not related to this PR).

</details>