### PR TITLE
[wip] Add windows-arm64 build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         $env:VULKAN_SDK="$(pwd)/VulkanSDK"
         mkdir build; cd build
-        cmake -A ARM64 ../src
+        cmake -A ARM64 -DNCNN_COMPILER_SUPPORT_ARM82_FP16=OFF ../src
         cmake --build . --config Release -j 2
 
   ubuntu:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
 env:
-  VK_VERSION: 1.3.261.1
+  VK_VERSION: 1.4.335.0
   VULKAN_SDK: vulkan-mac-sdk/macOS
 jobs:
   windows:
@@ -21,13 +21,38 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/$env:VK_VERSION/windows/VulkanSDK-$env:VK_VERSION-Installer.exe?Human=true -OutFile VulkanSDK-$env:VK_VERSION-Installer.exe
-        7z x -aoa ./VulkanSDK-$env:VK_VERSION-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/$env:VK_VERSION/windows/vulkansdk-windows-X64-$env:VK_VERSION.exe -OutFile VulkanSDK-$env:VK_VERSION-Installer.exe
+        & .\VulkanSDK-$env:VK_VERSION-Installer.exe --root ${pwd}\VulkanSDK --accept-licenses --default-answer --confirm-command install
     - name: build
       run: |
         $env:VULKAN_SDK="$(pwd)/VulkanSDK"
         mkdir build; cd build
         cmake -A x64 ../src
+        cmake --build . --config Release -j 2
+
+  windows-arm64:
+    runs-on: windows-11-arm
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: cache-vulkansdk
+      id: cache-vulkansdk
+      uses: actions/cache@v4
+      with:
+        path: "VulkanSDK"
+        key: "VulkanSDK-{{ env.VK_VERSION }}-Installer-arm64"
+    - name: vulkansdk
+      if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/$env:VK_VERSION/warm/vulkansdk-windows-ARM64-$env:VK_VERSION.exe -Outfile VulkanSDK-$env:VK_VERSION-Installer.exe
+        & .\VulkanSDK-$env:VK_VERSION-Installer.exe --root ${pwd}\VulkanSDK --accept-licenses --default-answer --confirm-command install
+    - name: build
+      run: |
+        $env:VULKAN_SDK="$(pwd)/VulkanSDK"
+        mkdir build; cd build
+        cmake -A ARM64 ../src
         cmake --build . --config Release -j 2
 
   ubuntu:


### PR DESCRIPTION
- Uses the native GHA Windows 11 on ARM runner
- Updates NCNN to a much newer version that knows how to configure for Windows ARM64
- Uses a newer Vulkan SDK. The installer doesn't support being extracted with 7z anymore, but it now has command line parameters to support CI scenarios and extraction to a custom folder.