### PR TITLE
Add daemon mode (-d) to keep model loaded for multiple batch processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ output/
 *.tar.xz
 upscayl-bin
 models/
+
+.cache

--- a/src/filesystem_utils.h
+++ b/src/filesystem_utils.h
@@ -176,10 +176,13 @@ static path_t get_executable_directory()
 static path_t get_executable_directory()
 {
     char filepath[256];
-    readlink("/proc/self/exe", filepath, 256);
+    ssize_t len = readlink("/proc/self/exe", filepath, sizeof(filepath) - 1);
+    if (len != -1)
+        filepath[len] = '\0';
 
     char *slash = strrchr(filepath, '/');
-    slash[1] = '\0';
+    if (slash != nullptr)
+        slash[1] = '\0';
 
     return path_t(filepath);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,7 +247,6 @@ static void print_daemon_help()
     fprintf(stderr, "Commands:\n");
     fprintf(stderr, "  -i input-path        input image path (jpg/png/webp) or directory\n");
     fprintf(stderr, "  -o output-path       output image path (jpg/png/webp) or directory\n");
-    fprintf(stderr, "  -z model-scale       scale according to the model (can be 2, 3, 4. default=4)\n");
     fprintf(stderr, "  -s output-scale      custom output scale (can be 2, 3, 4. default=4)\n");
     fprintf(stderr, "  -r resize            resize output to dimension (default=WxH:default), use '-r help' for more details\n");
     fprintf(stderr, "  -w width             resize output to a width (default=W:default), use '-r help' for more details\n");
@@ -1169,7 +1168,7 @@ static int run_daemon_mode(ProcessParams &params)
             wargv.push_back(a.data());
         }
         wargv.push_back(nullptr);
-        while ((opt = getopt(argc, wargv.data(), L"i:o:z:s:r:w:t:c:j:f:x")) != (wchar_t)-1)
+        while ((opt = getopt(argc, wargv.data(), L"i:o:s:r:w:t:c:j:f:x")) != (wchar_t)-1)
         {
             switch (opt)
             {
@@ -1178,9 +1177,6 @@ static int run_daemon_mode(ProcessParams &params)
                 break;
             case L'o':
                 output_str = optarg;
-                break;
-            case L'z':
-                params.scale = _wtoi(optarg);
                 break;
             case L's':
                 params.outputScale = _wtoi(optarg);
@@ -1247,7 +1243,7 @@ static int run_daemon_mode(ProcessParams &params)
 #else
         std::string input_str, output_str;
         int opt;
-        while ((opt = getopt(argc, argv.data(), "i:o:z:s:r:w:t:c:j:f:x")) != -1)
+        while ((opt = getopt(argc, argv.data(), "i:o:s:r:w:t:c:j:f:x")) != -1)
         {
             switch (opt)
             {
@@ -1256,9 +1252,6 @@ static int run_daemon_mode(ProcessParams &params)
                 break;
             case 'o':
                 output_str = optarg;
-                break;
-            case 'z':
-                params.scale = atoi(optarg);
                 break;
             case 's':
                 params.outputScale = atoi(optarg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,11 @@
 #include <vector>
 #include <clocale>
 #include <filesystem>
+#include <string>
+#if _WIN32
+#include <locale>
+#include <codecvt>
+#endif
 
 namespace fs = std::filesystem;
 
@@ -201,6 +206,7 @@ static void print_usage()
     fprintf(stderr, "  -h                   show this help\n");
     fprintf(stderr, "  -i input-path        input image path (jpg/png/webp) or directory\n");
     fprintf(stderr, "  -o output-path       output image path (jpg/png/webp) or directory\n");
+    fprintf(stderr, "  -d                   enable daemon/interactive mode\n");
     fprintf(stderr, "  -z model-scale       scale according to the model (can be 2, 3, 4. default=4)\n");
     fprintf(stderr, "  -s output-scale      custom output scale (can be 2, 3, 4. default=4)\n");
     fprintf(stderr, "  -r resize            resize output to dimension (default=WxH:default), use '-r help' for more details\n");
@@ -232,6 +238,29 @@ static void print_resize_usage()
     printf("  catmullrom    - An interpolating cubic spline\n");
     printf("  mitchell      - Mitchell-Netrevalli filter with B=1/3, C=1/3\n");
     printf("  pointsample   - Simple point sampling\n");
+}
+
+static void print_daemon_help()
+{
+    fprintf(stderr, "\n📡 Daemon Mode Help\n");
+    fprintf(stderr, "==================\n\n");
+    fprintf(stderr, "Commands:\n");
+    fprintf(stderr, "  -i input-path        input image path (jpg/png/webp) or directory\n");
+    fprintf(stderr, "  -o output-path       output image path (jpg/png/webp) or directory\n");
+    fprintf(stderr, "  -z model-scale       scale according to the model (can be 2, 3, 4. default=4)\n");
+    fprintf(stderr, "  -s output-scale      custom output scale (can be 2, 3, 4. default=4)\n");
+    fprintf(stderr, "  -r resize            resize output to dimension (default=WxH:default), use '-r help' for more details\n");
+    fprintf(stderr, "  -w width             resize output to a width (default=W:default), use '-r help' for more details\n");
+    fprintf(stderr, "  -c compress          compression of the output image, default 0 and varies to 100\n");
+    fprintf(stderr, "  -t tile-size         tile size (>=32/0=auto, default=0) can be 0,0,0 for multi-gpu\n");
+    fprintf(stderr, "  -j load:proc:save    thread count for load/proc/save (default=1:2:2) can be 1:2,2,2:2 for multi-gpu\n");
+    fprintf(stderr, "  -x                   enable tta mode\n");
+    fprintf(stderr, "  -f format            output image format (jpg/png/webp, default=ext/png)\n");
+    fprintf(stderr, "  help                 Show this help message\n");
+    fprintf(stderr, "  quit or exit         Exit daemon mode\n\n");
+    fprintf(stderr, "Examples:\n");
+    fprintf(stderr, "  -i input.jpg -o output.jpg        Process a single image\n");
+    fprintf(stderr, "  -i /path/to/dir -o /path/to/out   Process all images in a directory\n\n");
 }
 
 class Task
@@ -707,7 +736,7 @@ void *save(void *args)
         }
         if (success)
         {
-            fprintf(stderr, "100.00%\n");
+            fprintf(stderr, "100.00%%\n");
             fprintf(stderr, "\n🙌 Upscayled Successfully!\n");
 
             if (verbose)
@@ -733,6 +762,577 @@ void *save(void *args)
         {
             free((void*)v.outimage.data);
         }
+    }
+
+    return 0;
+}
+
+struct ProcessParams
+{
+    int scale;
+    int resizeWidth;
+    int resizeHeight;
+    int resizeMode;
+    int outputScale;
+    bool hasOutputScale;
+    float compression;
+    bool resizeProvided;
+    bool hasCustomWidth;
+    std::vector<int> tilesize;
+    path_t model;
+    path_t modelname;
+    std::vector<int> gpuid;
+    int jobs_load;
+    std::vector<int> jobs_proc;
+    int jobs_save;
+    int verbose;
+    int tta_mode;
+    path_t format;
+};
+
+static ProcessParams create_process_params(
+    int scale, int resizeWidth, int resizeHeight, int resizeMode,
+    int outputScale, bool hasOutputScale, float compression,
+    bool resizeProvided, bool hasCustomWidth,
+    const std::vector<int> &tilesize, const path_t &model,
+    const path_t &modelname, const std::vector<int> &gpuid,
+    int jobs_load, const std::vector<int> &jobs_proc, int jobs_save,
+    int verbose, int tta_mode, const path_t &format)
+{
+    ProcessParams params;
+    params.scale = scale;
+    params.resizeWidth = resizeWidth;
+    params.resizeHeight = resizeHeight;
+    params.resizeMode = resizeMode;
+    params.outputScale = outputScale;
+    params.hasOutputScale = hasOutputScale;
+    params.compression = compression;
+    params.resizeProvided = resizeProvided;
+    params.hasCustomWidth = hasCustomWidth;
+    params.tilesize = tilesize;
+    params.model = model;
+    params.modelname = modelname;
+    params.gpuid = gpuid;
+    params.jobs_load = jobs_load;
+    params.jobs_proc = jobs_proc;
+    params.jobs_save = jobs_save;
+    params.verbose = verbose;
+    params.tta_mode = tta_mode;
+    params.format = format;
+    return params;
+}
+
+static int process_image_batch(
+    const path_t &inputpath,
+    const path_t &outputpath,
+    const ProcessParams &params,
+    std::vector<RealESRGAN *> &realesrgan,
+    int prepadding)
+{
+    // collect input and output filepath
+    std::vector<path_t> input_files;
+    std::vector<path_t> output_files;
+    {
+        if (path_is_directory(inputpath) && path_is_directory(outputpath))
+        {
+            std::vector<path_t> filenames;
+            int lr = list_directory(inputpath, filenames);
+            if (lr != 0)
+                return -1;
+
+            const int count = filenames.size();
+            input_files.resize(count);
+            output_files.resize(count);
+
+            path_t last_filename;
+            path_t last_filename_noext;
+            for (int i = 0; i < count; i++)
+            {
+                path_t filename = filenames[i];
+                path_t filename_noext = get_file_name_without_extension(filename);
+                path_t output_filename = filename_noext + PATHSTR('.') + params.format;
+
+                // filename list is sorted, check if output image path conflicts
+                if (filename_noext == last_filename_noext)
+                {
+                    path_t output_filename2 = filename + PATHSTR('.') + params.format;
+#if _WIN32
+                    fwprintf(stderr, L"⚠️ Warning: both %s and %s output %s! %s will output %s\n", filename.c_str(), last_filename.c_str(), output_filename.c_str(), filename.c_str(), output_filename2.c_str());
+#else
+                    fprintf(stderr, "⚠️ Warning: both %s and %s output %s! %s will output %s\n", filename.c_str(), last_filename.c_str(), output_filename.c_str(), filename.c_str(), output_filename2.c_str());
+#endif
+                    output_filename = output_filename2;
+                }
+                else
+                {
+                    last_filename = filename;
+                    last_filename_noext = filename_noext;
+                }
+
+                input_files[i] = inputpath + PATHSTR('/') + filename;
+                output_files[i] = outputpath + PATHSTR('/') + output_filename;
+            }
+        }
+        else if (!path_is_directory(inputpath) && !path_is_directory(outputpath))
+        {
+            input_files.push_back(inputpath);
+            output_files.push_back(outputpath);
+        }
+        else
+        {
+            fprintf(stderr, "🚨 Error: Input path and Output path both must be either a file or a directory!\n");
+            return -1;
+        }
+    }
+
+    if (input_files.empty())
+    {
+        fprintf(stderr, "🚨 Error: No valid input files found!\n");
+        return -1;
+    }
+
+    fprintf(stderr, "🚀 Processing %d image(s)...\n", (int)input_files.size());
+
+    const int use_gpu_count = (int)params.gpuid.size();
+    int total_jobs_proc = 0;
+    for (int i = 0; i < use_gpu_count; i++)
+    {
+        total_jobs_proc += params.jobs_proc[i];
+    }
+
+    // main routine
+    {
+        // load image
+        LoadThreadParams ltp;
+        ltp.scale = params.scale;
+        ltp.jobs_load = params.jobs_load;
+        ltp.input_files = input_files;
+        ltp.output_files = output_files;
+
+        ncnn::Thread load_thread(load, (void *)&ltp);
+
+        // realesrgan proc
+        std::vector<ProcThreadParams> ptp(use_gpu_count);
+        for (int i = 0; i < use_gpu_count; i++)
+        {
+            ptp[i].realesrgan = realesrgan[i];
+        }
+
+        std::vector<ncnn::Thread *> proc_threads(total_jobs_proc);
+        {
+            int total_jobs_proc_id = 0;
+            for (int i = 0; i < use_gpu_count; i++)
+            {
+                for (int j = 0; j < params.jobs_proc[i]; j++)
+                {
+                    proc_threads[total_jobs_proc_id++] = new ncnn::Thread(proc, (void *)&ptp[i]);
+                }
+            }
+        }
+
+        // save image
+        SaveThreadParams stp;
+        stp.resizeWidth = params.resizeWidth;
+        stp.resizeHeight = params.resizeHeight;
+        stp.resizeMode = params.resizeMode;
+        stp.resizeProvided = params.resizeProvided;
+        stp.verbose = params.verbose;
+        stp.compression = params.compression;
+        stp.outputScale = params.outputScale;
+        stp.hasOutputScale = params.hasOutputScale;
+        stp.hasCustomWidth = params.hasCustomWidth;
+
+        std::vector<ncnn::Thread *> save_threads(params.jobs_save);
+        for (int i = 0; i < params.jobs_save; i++)
+        {
+            save_threads[i] = new ncnn::Thread(save, (void *)&stp);
+        }
+
+        // end
+        load_thread.join();
+
+        Task end;
+        end.id = -233;
+
+        for (int i = 0; i < total_jobs_proc; i++)
+        {
+            toproc.put(end);
+        }
+
+        for (int i = 0; i < total_jobs_proc; i++)
+        {
+            proc_threads[i]->join();
+            delete proc_threads[i];
+        }
+
+        for (int i = 0; i < params.jobs_save; i++)
+        {
+            tosave.put(end);
+        }
+
+        for (int i = 0; i < params.jobs_save; i++)
+        {
+            save_threads[i]->join();
+            delete save_threads[i];
+        }
+    }
+
+    return 0;
+}
+
+std::vector<std::string> split_cmdline(const std::string& cmd) {
+    std::vector<std::string> args;
+    std::string current;
+    bool in_quotes = false;
+
+    for (size_t i = 0; i < cmd.size(); ++i) {
+        char c = cmd[i];
+
+        if (c == '"') {
+            in_quotes = !in_quotes;
+        } else if (std::isspace(static_cast<unsigned char>(c)) && !in_quotes) {
+            if (!current.empty()) {
+                args.push_back(current);
+                current.clear();
+            }
+        } else {
+            current += c;
+        }
+    }
+
+    if (!current.empty())
+        args.push_back(current);
+
+    return args;
+}
+
+static int run_daemon_mode(ProcessParams &params)
+{
+    fprintf(stderr, "\n📡 Daemon Mode Started\n");
+
+    ProcessParams originalParams;
+    double compression = params.compression;
+    int resizeWidth = params.resizeWidth;
+    int resizeHeight = params.resizeHeight;
+    int resizeMode = params.resizeMode;
+    int jobs_load = params.jobs_load;
+    int jobs_save = params.jobs_save;
+
+    originalParams = params;
+
+    // Load model once and keep it in memory
+    int prepadding = 0;
+    if (params.model.find(PATHSTR("models")) != path_t::npos || params.model.find(PATHSTR("models2")) != path_t::npos)
+    {
+        prepadding = 10;
+    }
+    else
+    {
+        fprintf(stderr, "🚨 Error: Unknown model dir type. Make sure that the model directory is called 'models' with *.param and *.bin files inside it.\n");
+        return -1;
+    }
+
+#if _WIN32
+    wchar_t parampath[256];
+    wchar_t modelpath[256];
+
+    if (params.modelname == PATHSTR("realesr-animevideov3"))
+    {
+        swprintf(parampath, 256, L"%s/%s-x%d.param", params.model.c_str(), params.modelname.c_str(), params.scale);
+        swprintf(modelpath, 256, L"%s/%s-x%d.bin", params.model.c_str(), params.modelname.c_str(), params.scale);
+    }
+    else
+    {
+        swprintf(parampath, 256, L"%s/%s.param", params.model.c_str(), params.modelname.c_str());
+        swprintf(modelpath, 256, L"%s/%s.bin", params.model.c_str(), params.modelname.c_str());
+    }
+#else
+    char parampath[256];
+    char modelpath[256];
+
+    if (params.modelname == PATHSTR("realesr-animevideov3"))
+    {
+        snprintf(parampath, sizeof(parampath), "%s/%s-x%d.param", params.model.c_str(), params.modelname.c_str(), params.scale);
+        snprintf(modelpath, sizeof(modelpath), "%s/%s-x%d.bin", params.model.c_str(), params.modelname.c_str(), params.scale);
+    }
+    else
+    {
+        snprintf(parampath, sizeof(parampath), "%s/%s.param", params.model.c_str(), params.modelname.c_str());
+        snprintf(modelpath, sizeof(modelpath), "%s/%s.bin", params.model.c_str(), params.modelname.c_str());
+    }
+#endif
+
+    path_t paramfullpath = sanitize_filepath(parampath);
+    path_t modelfullpath = sanitize_filepath(modelpath);
+
+    const int use_gpu_count = (int)params.gpuid.size();
+    std::vector<RealESRGAN *> realesrgan(use_gpu_count);
+
+    fprintf(stderr, "🔧 Loading model...\n");
+    for (int i = 0; i < use_gpu_count; i++)
+    {
+        realesrgan[i] = new RealESRGAN(params.gpuid[i], params.tta_mode);
+        realesrgan[i]->load(paramfullpath, modelfullpath);
+        realesrgan[i]->scale = params.scale;
+        realesrgan[i]->tilesize = params.tilesize[i];
+        realesrgan[i]->prepadding = prepadding;
+    }
+    fprintf(stderr, "✅ Model loaded successfully!\n");
+#if _WIN32
+    fwprintf(stderr, L"Model: %s (scale: %dx)\n", params.modelname.c_str(), params.scale);
+#else
+    fprintf(stderr, "Model: %s (scale: %dx)\n", params.modelname.c_str(), params.scale);
+#endif
+    fprintf(stderr, "Type 'help' for usage or 'quit' to exit\n\n");
+
+    std::string line;
+    while (true)
+    {
+        fprintf(stderr, "📡 Ready> ");
+        if (!std::getline(std::cin, line))
+        {
+            break; // EOF or error
+        }
+
+        // Trim leading/trailing whitespace
+        size_t start = line.find_first_not_of(" \t\r\n");
+        size_t end = line.find_last_not_of(" \t\r\n");
+        if (start == std::string::npos)
+        {
+            continue; // Empty line
+        }
+        line = line.substr(start, end - start + 1);
+
+        if (line.empty())
+        {
+            continue;
+        }
+
+        if (line == "quit" || line == "exit")
+        {
+            fprintf(stderr, "👋 Exiting daemon mode...\n");
+            break;
+        }
+
+        if (line == "help")
+        {
+            print_daemon_help();
+            continue;
+        }
+
+        params = originalParams;
+
+        auto tokens = split_cmdline(line);
+
+        std::vector<std::string> parsed_args;
+        parsed_args.emplace_back("upscayl");
+        parsed_args.insert(parsed_args.end(), tokens.begin(), tokens.end());
+
+        std::vector<char*> argv;
+        for (auto& a : parsed_args)
+            argv.push_back(a.data());
+        argv.push_back(nullptr);
+
+        int argc = static_cast<int>(argv.size() - 1);
+
+        // Reset getopt global state
+        optind = 1;
+        optarg = NULL;
+
+#if _WIN32
+        std::wstring input_str, output_str;
+        wchar_t opt;
+        // Convert to wchar_t** for getopt on Windows
+        std::vector<std::wstring> wargs;
+        std::vector<wchar_t*> wargv;
+        for (int i = 0; i < argc; i++)
+        {
+            std::string str(argv[i]);
+            std::wstring wstr(str.begin(), str.end());
+            wargs.push_back(wstr);
+            wargv.push_back(wargs.back().data());
+        }
+        wargv.push_back(nullptr);
+        while ((opt = getopt(argc, wargv.data(), L"i:o:z:s:r:w:t:c:j:f:x")) != (wchar_t)-1)
+        {
+            switch (opt)
+            {
+            case L'i':
+                input_str = optarg;
+                break;
+            case L'o':
+                output_str = optarg;
+                break;
+            case L'z':
+                params.scale = _wtoi(optarg);
+                break;
+            case L's':
+                params.outputScale = _wtoi(optarg);
+                params.hasOutputScale = true;
+                break;
+            case L'c':
+                compression = _wtof(optarg);
+                if (compression < 0 || compression > 100)
+                {
+                    fwprintf(stderr, L"🚨 Error: Invalid compression value, it should be between 0 and 100!\n");
+                    return -1;
+                }
+                params.compression = round(compression / 10.0f) * 10.0f;
+                break;
+            case L'r':
+                if (wcscmp(optarg, L"help") == 0)
+                {
+                    print_resize_usage();
+                    return -1;
+                }
+                if (!parse_optarg_resize(optarg, &resizeWidth, &resizeHeight, &resizeMode))
+                {
+                    fwprintf(stderr, L"🚨 Error: Invalid resize value!\n");
+                    return -1;
+                }
+                params.resizeProvided = true;
+                params.resizeWidth = resizeWidth;
+                params.resizeHeight = resizeHeight;
+                params.resizeMode = resizeMode;
+                break;
+            case L'w':
+                if (wcscmp(optarg, L"help") == 0)
+                {
+                    print_resize_usage();
+                    return -1;
+                }
+                if (!parse_optarg_resize(optarg, &resizeWidth, &resizeHeight, &resizeMode, true))
+                {
+                    fwprintf(stderr, L"🚨 Error: Invalid resize value!\n");
+                    return -1;
+                }
+                params.hasCustomWidth = true;
+                params.resizeWidth = resizeWidth;
+                params.resizeHeight = resizeHeight;
+                params.resizeMode = resizeMode;
+                break;
+            case L't':
+                params.tilesize = parse_optarg_int_array(optarg);
+                break;
+            case L'j':
+                swscanf(optarg, L"%d:%*[^:]:%d", &jobs_load, &jobs_save);
+                params.jobs_proc = parse_optarg_int_array(wcschr(optarg, L':') + 1);
+                params.jobs_load = jobs_load;
+                params.jobs_save = jobs_save;
+                break;
+            case L'f':
+                params.format = optarg;
+                break;
+            case L'x':
+                params.tta_mode = 1;
+                break;
+            }
+        }
+#else
+        std::string input_str, output_str;
+        int opt;
+        while ((opt = getopt(argc, argv.data(), "i:o:z:s:r:w:t:c:j:f:x")) != -1)
+        {
+            switch (opt)
+            {
+            case 'i':
+                input_str = optarg;
+                break;
+            case 'o':
+                output_str = optarg;
+                break;
+            case 'z':
+                params.scale = atoi(optarg);
+                break;
+            case 's':
+                params.outputScale = atoi(optarg);
+                params.hasOutputScale = true;
+                break;
+            case 'c':
+                compression = atof(optarg);
+                if (compression < 0 || compression > 100)
+                {
+                    fprintf(stderr, "🚨 Error: Invalid compression value, it should be between 0 and 100!\n");
+                    return -1;
+                }
+                params.compression = round(compression / 10.0) * 10;
+                break;
+            case 'r':
+                if (strcmp(optarg, "help") == 0)
+                {
+                    print_resize_usage();
+                    return -1;
+                }
+                if (!parse_optarg_resize(optarg, &resizeWidth, &resizeHeight, &resizeMode))
+                {
+                    fprintf(stderr, "🚨 Error: Invalid resize value!\n");
+                    return -1;
+                }
+                params.resizeProvided = true;
+                params.resizeWidth = resizeWidth;
+                params.resizeHeight = resizeHeight;
+                params.resizeMode = resizeMode;
+                break;
+            case 'w':
+                if (strcmp(optarg, "help") == 0)
+                {
+                    print_resize_usage();
+                    return -1;
+                }
+                if (!parse_optarg_resize(optarg, &resizeWidth, &resizeHeight, &resizeMode, true))
+                {
+                    fprintf(stderr, "🚨 Error: Invalid resize value!\n");
+                    return -1;
+                }
+                params.hasCustomWidth = true;
+                params.resizeWidth = resizeWidth;
+                params.resizeHeight = resizeHeight;
+                params.resizeMode = resizeMode;
+                break;
+            case 't':
+                params.tilesize = parse_optarg_int_array(optarg);
+                break;
+            case 'j':
+                sscanf(optarg, "%d:%*[^:]:%d", &jobs_load, &jobs_save);
+                params.jobs_proc = parse_optarg_int_array(strchr(optarg, ':') + 1);
+                params.jobs_load = jobs_load;
+                params.jobs_save = jobs_save;
+                break;
+            case 'f':
+                params.format = optarg;
+                break;
+            case 'x':
+                params.tta_mode = 1;
+                break;
+            }
+        }
+#endif
+        
+        if (input_str.empty() || output_str.empty())
+        {
+            fprintf(stderr, "🚨 Error: Both input and output paths are required.\n\n");
+            continue;
+        }
+
+        path_t inputpath = input_str;
+        path_t outputpath = output_str;
+
+        // Process the images with pre-loaded model
+        int result = process_image_batch(inputpath, outputpath, params, realesrgan, prepadding);
+        if (result != 0)
+        {
+            fprintf(stderr, "❌ Processing failed\n\n");
+        }
+        else
+        {
+            fprintf(stderr, "\n");
+        }
+    }
+
+    // Clean up models
+    for (int i = 0; i < use_gpu_count; i++)
+    {
+        delete realesrgan[i];
     }
 
     return 0;
@@ -766,11 +1366,13 @@ int main(int argc, char **argv)
     int verbose = 0;
     int tta_mode = 0;
     path_t format = PATHSTR("png");
+    bool daemon_mode = false;
 
 #if _WIN32
     setlocale(LC_ALL, "");
     wchar_t opt;
-    while ((opt = getopt(argc, argv, L"i:o:z:s:r:w:t:c:m:n:g:j:f:vxh")) != (wchar_t)-1)
+    fprintf(stderr, "🚀 Starting Upscayl - Copyright © 2024\n");
+    while ((opt = getopt(argc, argv, L"i:o:z:s:r:w:t:c:m:n:g:j:f:vxhd")) != (wchar_t)-1)
     {
         switch (opt)
         {
@@ -847,6 +1449,9 @@ int main(int argc, char **argv)
         case L'x':
             tta_mode = 1;
             break;
+        case L'd':
+            daemon_mode = true;
+            break;
         case L'h':
         default:
             print_usage();
@@ -856,7 +1461,7 @@ int main(int argc, char **argv)
 #else  // _WIN32
     int opt;
     fprintf(stderr, "🚀 Starting Upscayl - Copyright © 2024\n");
-    while ((opt = getopt(argc, argv, "i:o:z:s:r:w:t:c:m:n:g:j:f:vxh")) != -1)
+    while ((opt = getopt(argc, argv, "i:o:z:s:r:w:t:c:m:n:g:j:f:vxhd")) != -1)
     {
         switch (opt)
         {
@@ -933,6 +1538,9 @@ int main(int argc, char **argv)
         case 'x':
             tta_mode = 1;
             break;
+        case 'd':
+            daemon_mode = true;
+            break;
         case 'h':
         default:
             print_usage();
@@ -940,7 +1548,7 @@ int main(int argc, char **argv)
         }
     }
 #endif // _WIN32
-    if (inputpath.empty() || outputpath.empty())
+    if (!daemon_mode && (inputpath.empty() || outputpath.empty()))
     {
         print_usage();
         return -1;
@@ -982,7 +1590,7 @@ int main(int argc, char **argv)
         }
     }
 
-    if (!path_is_directory(outputpath))
+    if (!daemon_mode && !path_is_directory(outputpath))
     {
         path_t ext = format;
 
@@ -1011,9 +1619,10 @@ int main(int argc, char **argv)
         return -1;
     }
 
-    // collect input and output filepath
+    // collect input and output filepath (skip in daemon mode)
     std::vector<path_t> input_files;
     std::vector<path_t> output_files;
+    if (!daemon_mode)
     {
         if (path_is_directory(inputpath) && path_is_directory(outputpath))
         {
@@ -1095,8 +1704,8 @@ int main(int argc, char **argv)
 
     if (modelname == PATHSTR("realesr-animevideov3"))
     {
-        swprintf(parampath, 256, L"%s/%s-x%s.param", model.c_str(), modelname.c_str(), std::to_string(scale));
-        swprintf(modelpath, 256, L"%s/%s-x%s.bin", model.c_str(), modelname.c_str(), std::to_string(scale));
+        swprintf(parampath, 256, L"%s/%s-x%d.param", model.c_str(), modelname.c_str(), scale);
+        swprintf(modelpath, 256, L"%s/%s-x%d.bin", model.c_str(), modelname.c_str(), scale);
     }
     else
     {
@@ -1147,13 +1756,13 @@ int main(int argc, char **argv)
 
     if (modelname == PATHSTR("realesr-animevideov3"))
     {
-        sprintf(parampath, "%s/%s-x%s.param", model.c_str(), modelname.c_str(), std::to_string(scale).c_str());
-        sprintf(modelpath, "%s/%s-x%s.bin", model.c_str(), modelname.c_str(), std::to_string(scale).c_str());
+        snprintf(parampath, sizeof(parampath), "%s/%s-x%d.param", model.c_str(), modelname.c_str(), scale);
+        snprintf(modelpath, sizeof(modelpath), "%s/%s-x%d.bin", model.c_str(), modelname.c_str(), scale);
     }
     else
     {
-        sprintf(parampath, "%s/%s.param", model.c_str(), modelname.c_str());
-        sprintf(modelpath, "%s/%s.bin", model.c_str(), modelname.c_str());
+        snprintf(parampath, sizeof(parampath), "%s/%s.param", model.c_str(), modelname.c_str());
+        snprintf(modelpath, sizeof(modelpath), "%s/%s.bin", model.c_str(), modelname.c_str());
     }
 #endif
 
@@ -1228,102 +1837,57 @@ int main(int argc, char **argv)
         }
     }
 
+    // Branch between daemon mode and single-run mode
+    if (daemon_mode)
     {
+        // Prepare parameters for daemon mode
+        ProcessParams params = create_process_params(
+            scale, resizeWidth, resizeHeight, resizeMode,
+            outputScale, hasOutputScale, compression,
+            resizeProvided, hasCustomWidth, tilesize, model,
+            modelname, gpuid, jobs_load, jobs_proc, jobs_save,
+            verbose, tta_mode, format);
+
+        int result = run_daemon_mode(params);
+        
+        ncnn::destroy_gpu_instance();
+        return result;
+    }
+
+    // Single-run mode: process the specified input/output paths
+    {
+        // Prepare parameters
+        ProcessParams params = create_process_params(
+            scale, resizeWidth, resizeHeight, resizeMode,
+            outputScale, hasOutputScale, compression,
+            resizeProvided, hasCustomWidth, tilesize, model,
+            modelname, gpuid, jobs_load, jobs_proc, jobs_save,
+            verbose, tta_mode, format);
+
         std::vector<RealESRGAN *> realesrgan(use_gpu_count);
 
         for (int i = 0; i < use_gpu_count; i++)
         {
             realesrgan[i] = new RealESRGAN(gpuid[i], tta_mode);
-
             realesrgan[i]->load(paramfullpath, modelfullpath);
-
             realesrgan[i]->scale = scale;
             realesrgan[i]->tilesize = tilesize[i];
             realesrgan[i]->prepadding = prepadding;
         }
 
-        // main routine
-        {
-            // load image
-            LoadThreadParams ltp;
-            ltp.scale = scale;
-            ltp.jobs_load = jobs_load;
-            ltp.input_files = input_files;
-            ltp.output_files = output_files;
-
-            ncnn::Thread load_thread(load, (void *)&ltp);
-
-            // realesrgan proc
-            std::vector<ProcThreadParams> ptp(use_gpu_count);
-            for (int i = 0; i < use_gpu_count; i++)
-            {
-                ptp[i].realesrgan = realesrgan[i];
-            }
-
-            std::vector<ncnn::Thread *> proc_threads(total_jobs_proc);
-            {
-                int total_jobs_proc_id = 0;
-                for (int i = 0; i < use_gpu_count; i++)
-                {
-                    for (int j = 0; j < jobs_proc[i]; j++)
-                    {
-                        proc_threads[total_jobs_proc_id++] = new ncnn::Thread(proc, (void *)&ptp[i]);
-                    }
-                }
-            }
-
-            // save image
-            SaveThreadParams stp;
-            stp.resizeWidth = resizeWidth;
-            stp.resizeHeight = resizeHeight;
-            stp.resizeMode = resizeMode;
-            stp.resizeProvided = resizeProvided;
-            stp.verbose = verbose;
-            stp.compression = compression;
-            stp.outputScale = outputScale;
-            stp.hasOutputScale = hasOutputScale;
-            stp.hasCustomWidth = hasCustomWidth;
-
-            std::vector<ncnn::Thread *> save_threads(jobs_save);
-            for (int i = 0; i < jobs_save; i++)
-            {
-                save_threads[i] = new ncnn::Thread(save, (void *)&stp);
-            }
-
-            // end
-            load_thread.join();
-
-            Task end;
-            end.id = -233;
-
-            for (int i = 0; i < total_jobs_proc; i++)
-            {
-                toproc.put(end);
-            }
-
-            for (int i = 0; i < total_jobs_proc; i++)
-            {
-                proc_threads[i]->join();
-                delete proc_threads[i];
-            }
-
-            for (int i = 0; i < jobs_save; i++)
-            {
-                tosave.put(end);
-            }
-
-            for (int i = 0; i < jobs_save; i++)
-            {
-                save_threads[i]->join();
-                delete save_threads[i];
-            }
-        }
+        int result = process_image_batch(inputpath, outputpath, params, realesrgan, prepadding);
 
         for (int i = 0; i < use_gpu_count; i++)
         {
             delete realesrgan[i];
         }
         realesrgan.clear();
+
+        if (result != 0)
+        {
+            ncnn::destroy_gpu_instance();
+            return result;
+        }
     }
 
     ncnn::destroy_gpu_instance();


### PR DESCRIPTION
I have added a daemon mode that allows the model to remain loaded in memory so images can be processed faster.

To make these changes, I had to rely on Copilot, since my knowledge of C++ is limited. I reviewed the parts of the code generated by and I fixed all issues. I also tested it on both Linux and Windows, and it works correctly (both the new daemon mode and the normal mode). I haven't been able to test it on macOS because I don't have a Mac.

With daemon mode, the model can be loaded at startup so that when the user interacts (for example, in Upscayl), the image is processed much faster. At least on my graphics card (AMD RX 6700, on both Linux and Windows), the model loading time is considerably high (several seconds), and with this mode that cost can be avoided for each image. For some models, the loading time is even slower than the actual image processing time.

You can also see my implementation of process spawning in Node in this other repository:
https://github.com/ollm/opencomic-ai-bin
https://github.com/ollm/opencomic-ai-bin/blob/b348e3754245cb633d02937d35a7270e53670c3a/index.mts#L1221


## Example usage

``` bash
./upscayl-bin -d -m /path/to/models -n realesrgan-x4plus -z 4
🚀 Starting Upscayl - Copyright © 2024
✨ Detected scale x4
✨ Using the default scale x4
[0 AMD Radeon Graphics (RADV NAVI22)]  queueC=1[4]  queueG=0[1]  queueT=0[1]
[0 AMD Radeon Graphics (RADV NAVI22)]  bugsbn1=0  bugbilz=0  bugcopc=0  bugihfa=0
[0 AMD Radeon Graphics (RADV NAVI22)]  fp16-p/s/a=1/1/1  int8-p/s/a=1/1/1
[0 AMD Radeon Graphics (RADV NAVI22)]  subgroup=64  basic=1  vote=1  ballot=1  shuffle=1
[1 llvmpipe (LLVM 20.1.2, 256 bits)]  queueC=0[1]  queueG=0[1]  queueT=0[1]
[1 llvmpipe (LLVM 20.1.2, 256 bits)]  bugsbn1=0  bugbilz=0  bugcopc=0  bugihfa=0
[1 llvmpipe (LLVM 20.1.2, 256 bits)]  fp16-p/s/a=1/1/1  int8-p/s/a=1/1/1
[1 llvmpipe (LLVM 20.1.2, 256 bits)]  subgroup=8  basic=1  vote=1  ballot=1  shuffle=1

📡 Daemon Mode Started
🔧 Loading model...
✅ Model loaded successfully!
Model: realesrgan-x4plus (scale: 4x)
Type 'help' for usage or 'quit' to exit

📡 Ready> -i input.jpg -o output.jpg -s 4
```

## Daemon comparative performance

### Table (10 images 512x512px)

Model                          | Disabled              | Enabled              | Disabled vs Enabled
-------------------------------|-----------------------|----------------------|--------
OpenComic AI Upscale Lite      | 52.087s               | 7.646s               | 6.81x
RealESRGAN x4 Plus             | 73.273s               | 23.199s              | 3.16x

### OpenComic AI Upscale Lite

#### Disabled

``` bash
Processing image 1/10 for model: OpenComic AI Upscale Lite: 2.931s
Processing image 2/10 for model: OpenComic AI Upscale Lite: 4.464s
Processing image 3/10 for model: OpenComic AI Upscale Lite: 5.594s
Processing image 4/10 for model: OpenComic AI Upscale Lite: 5.561s
Processing image 5/10 for model: OpenComic AI Upscale Lite: 5.521s
Processing image 6/10 for model: OpenComic AI Upscale Lite: 5.531s
Processing image 7/10 for model: OpenComic AI Upscale Lite: 5.534s
Processing image 8/10 for model: OpenComic AI Upscale Lite: 5.555s
Processing image 9/10 for model: OpenComic AI Upscale Lite: 5.496s
Processing image 10/10 for model: OpenComic AI Upscale Lite: 5.898s
Model: OpenComic AI Upscale Lite, Latency: 52.087s
```

#### Enabled

``` bash
Preloading model... OpenComic AI Upscale Lite
Preload model: OpenComic AI Upscale Lite: 473.897ms
Processing image 1/10 for model: OpenComic AI Upscale Lite: 725.474ms
Processing image 2/10 for model: OpenComic AI Upscale Lite: 716.566ms
Processing image 3/10 for model: OpenComic AI Upscale Lite: 716.221ms
Processing image 4/10 for model: OpenComic AI Upscale Lite: 715.214ms
Processing image 5/10 for model: OpenComic AI Upscale Lite: 717.894ms
Processing image 6/10 for model: OpenComic AI Upscale Lite: 715.236ms
Processing image 7/10 for model: OpenComic AI Upscale Lite: 716.296ms
Processing image 8/10 for model: OpenComic AI Upscale Lite: 714.025ms
Processing image 9/10 for model: OpenComic AI Upscale Lite: 718.653ms
Processing image 10/10 for model: OpenComic AI Upscale Lite: 714.792ms
Model: OpenComic AI Upscale Lite, Latency: 7.646s
```

### RealESRGAN x4 Plus

#### Disabled

``` bash
Processing image 1/10 for model: RealESRGAN x4 Plus: 6.473s
Processing image 2/10 for model: RealESRGAN x4 Plus: 7.809s
Processing image 3/10 for model: RealESRGAN x4 Plus: 7.690s
Processing image 4/10 for model: RealESRGAN x4 Plus: 7.470s
Processing image 5/10 for model: RealESRGAN x4 Plus: 6.620s
Processing image 6/10 for model: RealESRGAN x4 Plus: 7.390s
Processing image 7/10 for model: RealESRGAN x4 Plus: 7.423s
Processing image 8/10 for model: RealESRGAN x4 Plus: 7.541s
Processing image 9/10 for model: RealESRGAN x4 Plus: 7.536s
Processing image 10/10 for model: RealESRGAN x4 Plus: 7.321s
Model: RealESRGAN x4 Plus, Latency: 73.273s
```

#### Enabled
``` bash
Preloading model... RealESRGAN x4 Plus
Preload model: RealESRGAN x4 Plus: 1.165s
Processing image 1/10 for model: RealESRGAN x4 Plus: 2.217s
Processing image 2/10 for model: RealESRGAN x4 Plus: 2.196s
Processing image 3/10 for model: RealESRGAN x4 Plus: 2.203s
Processing image 4/10 for model: RealESRGAN x4 Plus: 2.191s
Processing image 5/10 for model: RealESRGAN x4 Plus: 2.200s
Processing image 6/10 for model: RealESRGAN x4 Plus: 2.203s
Processing image 7/10 for model: RealESRGAN x4 Plus: 2.216s
Processing image 8/10 for model: RealESRGAN x4 Plus: 2.222s
Processing image 9/10 for model: RealESRGAN x4 Plus: 2.188s
Processing image 10/10 for model: RealESRGAN x4 Plus: 2.194s
Model: RealESRGAN x4 Plus, Latency: 23.199s
```